### PR TITLE
feat: Frontend API Connection

### DIFF
--- a/src/main/java/com/erp/oneflow/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/erp/oneflow/infrastructure/config/SecurityConfig.java
@@ -1,0 +1,51 @@
+package com.erp.oneflow.infrastructure.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/**").permitAll()
+                        .anyRequest().permitAll()
+                )
+                .formLogin(form -> form.disable())
+                .httpBasic(httpBasic -> httpBasic.disable());
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of("http://localhost:3000"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setExposedHeaders(List.of("Authorization"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
+}

--- a/src/main/java/com/erp/oneflow/presentation/user/controller/UserController.java
+++ b/src/main/java/com/erp/oneflow/presentation/user/controller/UserController.java
@@ -1,4 +1,16 @@
 package com.erp.oneflow.presentation.user.controller;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
 public class UserController {
+
+    @GetMapping("/test")
+    public String testApi() {
+        return "백엔드 연결 성공";
+    }
+
 }


### PR DESCRIPTION
Summary
Frontend <-> Backend 간 API 요청을 정상적으로 수행할 수 있도록 기능을 구현하고,  
Controller의 API를 통해 테스트를 진행하였습니다.

1. Security Setting
  - Spring Security CORS 설정 추가
  - CSRF 비활성화
  - Spring Security 기본 로그인 & HTTP Basic 인증 제거

2. Controller Method Test
  - '/api/test' 엔드포인트 추가 및 응답 확인